### PR TITLE
Fix FFT issues

### DIFF
--- a/misc_crypto/plonk/constraint.py
+++ b/misc_crypto/plonk/constraint.py
@@ -5,14 +5,10 @@ from typing import Sequence, Dict, Union, Tuple, NewType
 from .field import FieldElement
 from dataclasses import dataclass
 from enum import Enum
-from math import log2, ceil
+from .utils import next_power_of_2
 
 
 WireIndex = NewType("WireIndex", int)
-
-
-def next_power_of_2(n: int) -> int:
-    return 1 << ceil(log2(n))
 
 
 @dataclass

--- a/misc_crypto/plonk/fft.py
+++ b/misc_crypto/plonk/fft.py
@@ -3,26 +3,28 @@ Fast Fourier Transform:
 See https://vitalik.ca/general/2019/05/12/fft.html for motivation
 """
 from typing import Sequence
-from .field import FieldElement
-
-
-def is_power_of_2(n: int) -> bool:
-    return (n & (n - 1) == 0) and n != 0
+from .field import FieldElement, Fr
+from .utils import is_power_of_2
 
 
 def fft(
     coefficients: Sequence[FieldElement], domain: Sequence[FieldElement]
 ) -> Sequence[FieldElement]:
     len_coeff, len_domain = len(coefficients), len(domain)
-    if not is_power_of_2(len_coeff):
-        raise ValueError(
-            "length of coefficients should be a power of 2, got", len_coeff
-        )
 
     if not is_power_of_2(len_domain):
         raise ValueError("length of domain should be a power of 2, got", len_domain)
 
-    return _fft(coefficients, domain)
+    if len_coeff > len_domain:
+        raise ValueError(
+            (
+                f"The number of coefficients ({len_coeff}) should not be larger than "
+                f"the length of domain ({len_domain})"
+            )
+        )
+    padded_coefficients = tuple(coefficients) + (Fr(0),) * (len_domain - len_coeff)
+
+    return _fft(padded_coefficients, domain)
 
 
 def _fft(

--- a/misc_crypto/plonk/fft.py
+++ b/misc_crypto/plonk/fft.py
@@ -1,0 +1,49 @@
+"""
+Fast Fourier Transform:
+See https://vitalik.ca/general/2019/05/12/fft.html for motivation
+"""
+from typing import Sequence
+from .field import FieldElement
+
+
+def is_power_of_2(n: int) -> bool:
+    return (n & (n - 1) == 0) and n != 0
+
+
+def fft(
+    coefficients: Sequence[FieldElement], domain: Sequence[FieldElement]
+) -> Sequence[FieldElement]:
+    len_coeff, len_domain = len(coefficients), len(domain)
+    if not is_power_of_2(len_coeff):
+        raise ValueError(
+            "length of coefficients should be a power of 2, got", len_coeff
+        )
+
+    if not is_power_of_2(len_domain):
+        raise ValueError("length of domain should be a power of 2, got", len_domain)
+
+    return _fft(coefficients, domain)
+
+
+def _fft(
+    coefficients: Sequence[FieldElement], domain: Sequence[FieldElement]
+) -> Sequence[FieldElement]:
+    if len(coefficients) == 1:
+        return coefficients
+    evens = fft(coefficients[::2], domain[::2])
+    odds = fft(coefficients[1::2], domain[::2])
+    left_output = []
+    right_output = []
+    for even, odd, x in zip(evens, odds, domain):
+        x_odd = x * odd
+        left_output.append(even + x_odd)
+        right_output.append(even - x_odd)
+    return left_output + right_output
+
+
+def inverse_fft(
+    evaluations: Sequence[FieldElement], domain: Sequence[FieldElement]
+) -> Sequence[FieldElement]:
+    values = fft(evaluations, domain)
+    len_values = len(values)
+    return [v / len_values for v in [values[0]] + values[1:][::-1]]

--- a/misc_crypto/plonk/field.py
+++ b/misc_crypto/plonk/field.py
@@ -68,6 +68,8 @@ class FieldElement(Protocol):
 
 
 def roots_of_unity(order: int) -> Tuple[Fr, ...]:
+    # TODO: Check the multiplicative subgroup must have size  2^n
+    # TODO: Support fields other than Fr
     a = Fr(5)
-    p = Fr.field_modulus
-    return tuple(a ** (i * (p - 1) / order) for i in range(order))
+    p = Fr.field_modulus - 1
+    return tuple(a ** ((i * p) // order) for i in range(order))

--- a/misc_crypto/plonk/polynomial.py
+++ b/misc_crypto/plonk/polynomial.py
@@ -1,32 +1,7 @@
 from typing import Sequence, Union
 from .field import FieldElement, roots_of_unity
 from dataclasses import dataclass
-
-
-def fft(
-    coefficients: Sequence[FieldElement], domain: Sequence[FieldElement]
-) -> Sequence[FieldElement]:
-    # TODO: Check domain to be power of 2
-    if len(coefficients) == 1:
-        return coefficients
-    evens = fft(coefficients[::2], domain[::2])
-    odds = fft(coefficients[1::2], domain[::2])
-    left_output = []
-    right_output = []
-    for even, odd, x in zip(evens, odds, domain):
-        x_odd = x * odd
-        left_output.append(even + x_odd)
-        right_output.append(even - x_odd)
-    return left_output + right_output
-
-
-def inverse_fft(
-    evaluations: Sequence[FieldElement], domain: Sequence[FieldElement]
-) -> Sequence[FieldElement]:
-    values = fft(evaluations, domain)
-    # TODO: len_values should be mod field modulus. The function breaks in small field
-    len_values = len(values)
-    return [v / len_values for v in [values[0]] + values[1:][::-1]]
+from .fft import fft, inverse_fft
 
 
 @dataclass

--- a/misc_crypto/plonk/polynomial.py
+++ b/misc_crypto/plonk/polynomial.py
@@ -2,6 +2,7 @@ from typing import Sequence, Union
 from .field import FieldElement, roots_of_unity
 from dataclasses import dataclass
 from .fft import fft, inverse_fft
+from .utils import next_power_of_2
 
 
 @dataclass
@@ -10,7 +11,8 @@ class EvaluationDomain:
 
     @classmethod
     def from_roots_of_unity(cls, order: int):
-        domain = roots_of_unity(order)
+        power_of_2_order = next_power_of_2(order)
+        domain = roots_of_unity(power_of_2_order)
         return cls(domain)
 
     def inverse_fft(self, evaluations: Sequence[FieldElement]) -> "Polynomial":
@@ -169,7 +171,7 @@ class Polynomial:
             remainder -= multiplier * other
 
         if not remainder.is_zero:
-            raise ValueError("Remainder is not zero:", r)
+            raise ValueError("Remainder is not zero:", remainder)
 
         return quotient
 
@@ -203,7 +205,9 @@ def permutation_polynomial_evalutations(
     Returns evalutaions
     """
     z = [1]
-    for f, s_id_eval, s_sigma_eval in zip(f_evaluations, s_id_evals, s_sigma_evals):
+    # We want z has same length as f_evaluations
+    _zip = zip(f_evaluations[:-1], s_id_evals[:-1], s_sigma_evals[:-1])
+    for f, s_id_eval, s_sigma_eval in _zip:
         f_prime = f + beta * s_id_eval + gamma
         g_prime = f + beta * s_sigma_eval + gamma
         product = z[-1] * f_prime / g_prime

--- a/misc_crypto/plonk/prover.py
+++ b/misc_crypto/plonk/prover.py
@@ -57,23 +57,28 @@ def prove(prover_input: ProverInput, srs: SRS):
 
     l1 = vanishing / (Polynomial(-1, 1) * n)  # (x^n - 1)/ ((x - 1) * n)
     satisfication = compute_satisfication_polynomial(a, b, c, prover_input, eval_domain)
-    t1  = satisfication * alpha / vanishing
-    # Compute quotient polynomial
-    t = (
-        t1
-        + (a + Polynomial(gamma, beta))
+    t1 = satisfication * alpha / vanishing
+
+    t2 = (
+        (a + Polynomial(gamma, beta))
         * (b + Polynomial(gamma, beta * K1))
-        * (c + Polynomial(gamma, beta * K2) * z)
+        * (c + Polynomial(gamma, beta * K2))
+        * z
         * alpha ** 2
         / vanishing
-        - (a + beta * sigma1 + gamma)
+    )
+    t3 = (
+        (a + beta * sigma1 + gamma)
         * (b + beta * sigma2 + gamma)
         * (c + beta * sigma3 + gamma)
         * z.shift(1)
         * alpha ** 2
         / vanishing
-        + (z - 1) * l1 * alpha ** 3 / vanishing
     )
+    t4 = (z - 1) * l1 * alpha ** 3 / vanishing
+
+    # Compute quotient polynomial
+    t = t1 + t2 - t3 + t4
     coeff = t.coefficients
     t_lo = Polynomial(*coeff[:n])
     t_mid = Polynomial(*coeff[n : 2 * n])

--- a/misc_crypto/plonk/prover.py
+++ b/misc_crypto/plonk/prover.py
@@ -3,6 +3,7 @@ from typing import Sequence
 from .polynomial import Polynomial, lagrange, EvaluationDomain
 from .commitment import commit, SRS
 from .constraint import ProverInput
+from .constants import K1, K2
 
 from .helpers import (
     custom_hash,
@@ -20,7 +21,8 @@ def get_public_input(witnesses):
 def prove(prover_input: ProverInput, srs: SRS):
     n = prover_input.number_of_gates()
     witnesses = prover_input.witnesses
-    eval_domain = EvaluationDomain.from_roots_of_unity(n)
+    # Make the domain larger just in case
+    eval_domain = EvaluationDomain.from_roots_of_unity(3 * n)
     vanishing = vanishing_polynomial(n)
 
     # TODO: make it random
@@ -55,12 +57,13 @@ def prove(prover_input: ProverInput, srs: SRS):
 
     l1 = vanishing / (Polynomial(-1, 1) * n)  # (x^n - 1)/ ((x - 1) * n)
     satisfication = compute_satisfication_polynomial(a, b, c, prover_input, eval_domain)
+    t1  = satisfication * alpha / vanishing
     # Compute quotient polynomial
     t = (
-        satisfication * alpha / vanishing
+        t1
         + (a + Polynomial(gamma, beta))
-        * (b + Polynomial(gamma, beta * k1))
-        * (c + Polynomial(gamma, beta * k2) * z)
+        * (b + Polynomial(gamma, beta * K1))
+        * (c + Polynomial(gamma, beta * K2) * z)
         * alpha ** 2
         / vanishing
         - (a + beta * sigma1 + gamma)

--- a/misc_crypto/plonk/utils.py
+++ b/misc_crypto/plonk/utils.py
@@ -1,0 +1,8 @@
+from math import log2, ceil
+
+def is_power_of_2(n: int) -> bool:
+    return (n & (n - 1) == 0) and n != 0
+
+
+def next_power_of_2(n: int) -> int:
+    return 1 << ceil(log2(n))

--- a/misc_crypto/plonk/utils.py
+++ b/misc_crypto/plonk/utils.py
@@ -1,5 +1,6 @@
 from math import log2, ceil
 
+
 def is_power_of_2(n: int) -> bool:
     return (n & (n - 1) == 0) and n != 0
 

--- a/tests/test_plonk.py
+++ b/tests/test_plonk.py
@@ -116,7 +116,7 @@ def test_circuit():
     assert c.num_non_trivial_gates() == 6
     assert len(c.gates) == 8
 
-    # MUL MUL ADD INP ADD INP
+    # MUL MUL ADD INP ADD INP DUM DUM
     assert gate_vector.a == [3, 9, 3, 5, 30, 35, 0, 0]
     assert gate_vector.b == [3, 3, 27, 0, 5, 0, 0, 0]
     assert gate_vector.c == [9, 27, 30, 5, 35, 35, 0, 0]
@@ -174,13 +174,13 @@ def test_permutation_polynomial_evalutations():
     evals = permutation_polynomial_evalutations(
         beta, gamma, f_evaluations, s_id_evals, s_sigma_evals
     )
-    assert evals == [1, 1, 4, 12]
+    assert evals == [1, 1, 4]
 
 
 @pytest.mark.xfail(reason="Work in progress")
 def test_prover():
 
-    srs = srs_setup(10, 5)
+    srs = srs_setup(64, 5)
 
     c = circuit()
     input_mapping = {"x": 3, "const": 5, "y": 35}

--- a/tests/test_plonk.py
+++ b/tests/test_plonk.py
@@ -5,7 +5,7 @@ from misc_crypto.plonk.polynomial import (
     permutation_polynomial_evalutations,
 )
 
-from misc_crypto.plonk.field import Fr, FQ
+from misc_crypto.plonk.field import Fr, FQ, roots_of_unity
 
 from misc_crypto.plonk.commitment import (
     srs_setup,
@@ -131,6 +131,11 @@ def test_circuit():
     prover_input = c.get_prover_input()
 
     assert prover_input.get_public_input_evaluations() == [0, 0, 0, -5, 0, -35]
+
+
+def test_roots_of_unity():
+    roots = roots_of_unity(8)
+    assert roots[1] * roots[-1] == 1
 
 
 def test_fft():

--- a/tests/test_plonk.py
+++ b/tests/test_plonk.py
@@ -113,24 +113,27 @@ def test_circuit():
     gate_vector = c.get_gate_vector()
 
     assert len(c.wires) == 10
-    assert len(c.gates) == 6
+    assert c.num_non_trivial_gates() == 6
+    assert len(c.gates) == 8
 
     # MUL MUL ADD INP ADD INP
-    assert gate_vector.a == [3, 9, 3, 5, 30, 35]
-    assert gate_vector.b == [3, 3, 27, 0, 5, 0]
-    assert gate_vector.c == [9, 27, 30, 5, 35, 35]
+    assert gate_vector.a == [3, 9, 3, 5, 30, 35, 0, 0]
+    assert gate_vector.b == [3, 3, 27, 0, 5, 0, 0, 0]
+    assert gate_vector.c == [9, 27, 30, 5, 35, 35, 0, 0]
 
     gate_wire_vector = c.get_gate_wire_vector()
-    assert gate_wire_vector.a == [0, 1, 0, 4, 3, 7]
-    assert gate_wire_vector.b == [0, 0, 2, -1, 5, -1]
-    assert gate_wire_vector.c == [1, 2, 3, 5, 6, 8]
+    assert gate_wire_vector.a == [0, 1, 0, 4, 3, 7, -1, -1]
+    assert gate_wire_vector.b == [0, 0, 2, -1, 5, -1, -1, -1]
+    assert gate_wire_vector.c == [1, 2, 3, 5, 6, 8, -1, -1]
 
     assert c.get_permutation() == (
-        [7, 12, 0, 3, 14, 5, 2, 6, 13, 11, 15, 9, 1, 8, 4, 10, 16, 17]
+        [9, 16, 0, 3, 18, 5, 23, 6,]
+        + [2, 8, 17, 7, 19, 11, 13, 14,]
+        + [1, 10, 4, 12, 20, 21, 15, 22,]
     )
     prover_input = c.get_prover_input()
 
-    assert prover_input.get_public_input_evaluations() == [0, 0, 0, -5, 0, -35]
+    assert prover_input.get_public_input_evaluations() == [0, 0, 0, -5, 0, -35, 0, 0]
 
 
 def test_roots_of_unity():

--- a/tests/test_plonk.py
+++ b/tests/test_plonk.py
@@ -151,6 +151,12 @@ def test_fft():
     assert p2.coefficients == (3, 1, 4, 1, 5, 9, 2, 6)
 
 
+def test_fft_2():
+    ed = EvaluationDomain.from_roots_of_unity(8)
+    evaluations = [3, 9, 3, 5, 30, 35, 0, 0]
+    assert ed.inverse_fft(evaluations).fft(ed) == evaluations
+
+
 def test_permutation_polynomial_evalutations():
     class F13(FQ):
         field_modulus = 13


### PR DESCRIPTION
FFT doesn't just work magically on any domain and any evaluations.

We need to enforce these to the input of FFT.

- The domain must be a subgroup of a size that is a power of 2.
- The size of evaluations must be a power of 2 too.

